### PR TITLE
fix: uploads causing not defined error

### DIFF
--- a/backend/server/controllers/homeAdvisoryController.js
+++ b/backend/server/controllers/homeAdvisoryController.js
@@ -1,4 +1,19 @@
 const HomeAdvisory = require('../models/HomeAdvisory.js');
+const multer = require('multer');
+const path = require("path");
+
+
+// This will be used in router.js as middleware for the thumbnail of the home advisories
+const storage = multer.diskStorage({
+  destination: function(req, file, callback) {
+      callback(null, path.join(__dirname, '../uploads/home_advisory'));
+  },
+  filename: function(req, file, callback) {
+      callback(null, "s-" + Date.now() + "-" + file.originalname);
+  }
+});
+const uploads = multer({ storage }).single('home_advisory');
+
 
 module.exports = {
   getAll,
@@ -48,26 +63,6 @@ async function update(req, res) {
   }
 }
 
-
-//
-
-
-
-
-//
-const multer = require('multer');
-const path = require("path");
-
-// This will be used in router.js as middleware for the thumbnail of the home advisories
-const storage = multer.diskStorage({
-    destination: function(req, file, callback) {
-        callback(null, path.join(__dirname, '../uploads/home_advisory'));
-    },
-    filename: function(req, file, callback) {
-        callback(null, "s-" + Date.now() + "-" + file.originalname);
-    }
-});
-const uploads = multer({ storage }).single('home_advisory');
 
 
 // route for uploading a thumbnail image to a HomeAdvisory


### PR DESCRIPTION
The uploads middleware should be defined before exporting. This is now
fixed by moving the upload definition to the top of the controller file.